### PR TITLE
Set ON_ERROR_STOP when running SQL migration

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- SQL migrations will now terminate on the first error in the script rather
+  continuing on error. Closes RT #120488.
+
+
 0.05     2015-07-28
 
 - Added support for all missing createdb options: --locale, --lc-collate,

--- a/lib/Database/Migrator/Pg.pm
+++ b/lib/Database/Migrator/Pg.pm
@@ -86,6 +86,7 @@ sub _run_ddl {
         'execute_file',
         database => $self->database,
         file     => $file,
+        options  => [ -v => 'ON_ERROR_STOP=1' ],
     );
 
     return;


### PR DESCRIPTION
Unfortunately, there aren't any existing tests of the actual migration functionality and I did not add any specific to this behavior. I did manually test the change.